### PR TITLE
Update workflow and configure for deploy button

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,19 +17,9 @@ jobs:
         node-version: '10.x'
     - name: Install deps
       run: npm install
-    - name: Install Wrangler
-      run: npm i @cloudflare/wrangler@1.4.0-rc.7 -g
-    - name: Install Workers script deps
-      run: npm install
-    - name: Build Workers script
-      run: wrangler build
-    - name: Wrangler auth check
-      run: wrangler whoami
+    - name: Publish
+      uses: cloudflare/wrangler-action@1.2.0
+      with:
+        apiToken: ${{ secrets.CF_API_TOKEN }}
       env:
-        CF_API_KEY: ${{ secrets.CF_API_KEY }}
-        CF_EMAIL: ${{ secrets.CF_EMAIL }}
-    - name: Upload assets
-      run: wrangler publish
-      env:
-        CF_API_KEY: ${{ secrets.CF_API_KEY }}
-        CF_EMAIL: ${{ secrets.CF_EMAIL }}
+        CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Web Scraper makes it effortless to scrape websites. You provide a URL and CSS se
 
 [Website →](http://web.scraper.workers.dev)
 
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/adamschwartz/web.scraper.workers.dev)
 
 ## Examples
 


### PR DESCRIPTION
This PR updates the GitHub workflow to use `wrangler-action` and work with the incoming [Deploy](https://deploy.workers.cloudflare.com) functionality.

There's also a secrets change - instead of using CF_API_KEY and CF_EMAIL, we should be using CF_API_TOKEN!

Finally, the Deploy Button is added to the project README for easy deployment.

See https://github.com/signalnerve/web.scraper.workers.dev/runs/1004064223 for an example build